### PR TITLE
fix(deps): force-bump vulnerable transitive crates via [patch.crates-io]

### DIFF
--- a/disinfo-nesy-detector/Cargo.toml
+++ b/disinfo-nesy-detector/Cargo.toml
@@ -44,3 +44,10 @@ futures = "0.3"
 [[bin]]
 name = "nsai-detector"
 path = "src/main.rs"
+
+# Force-bumped vulnerable transitive crates to patched versions
+# (added 2026-05-12 dependabot sweep — see PR description).
+# May require code adjustments if API has changed; CI surfaces this.
+[patch.crates-io]
+rand = { version = "0.8.6" }
+rustls-webpki = { version = "0.103.13" }


### PR DESCRIPTION
fix(deps): force-bump vulnerable transitive crates via [patch.crates-io]

Cargo.toml constraints in this repo prevented cargo update from
materialising patched versions of transitive dependencies with open
Dependabot alerts. Adding [patch.crates-io] entries to force the
lockfile onto patched versions.

Materialised:
  - rand=0.8.6

Still pending (override didn't reach lockfile — may need parent-dep bump):
  - rustls-webpki (lock=0.102.8, want=0.103.13)

⚠️  This is a force-bump. CI may surface API breakage if the patched
    version has incompatible changes vs the parent dep's expectations.
    Treat CI failure here as a signal to update the parent dep too.
