### PR TITLE
docs(readme): flip stale PMPL-1.0 license badge to MPL-2.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 = Misinformation Defence Platform
 
-image:https://img.shields.io/badge/License-PMPL--1.0-blue.svg[License: PMPL-1.0,link="https://github.com/hyperpolymath/palimpsest-license"]
+image:https://img.shields.io/badge/License-MPL--2.0-blue.svg[License: MPL-2.0,link="https://www.mozilla.org/MPL/2.0/"]
 :toc:
 :toc-placement!:
 :icons: font


### PR DESCRIPTION
Single-line README badge polish.