### PR TITLE
security(deps): bump rustls-webpki->0.103.13 (GHSA-82j2-j2ch-gfr8, HIGH)

### DIFF
--- a/disinfo-nesy-detector/Cargo.lock
+++ b/disinfo-nesy-detector/Cargo.lock
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## What

Lockfile-only bump of `rustls-webpki` from **0.103.11 -> 0.103.13** in `disinfo-nesy-detector/Cargo.lock`. No `Cargo.toml`, licence/SPDX, or `.gitattributes` files were touched. The bump is confined to the existing `0.103.x` line (no major/breaking parent change). The crate's runtime dependency set is identical between 0.103.11 and 0.103.13, so this is a safe in-line patch bump; it also realises the `[patch.crates-io] rustls-webpki = { version = "0.103.13" }` already declared in `Cargo.toml`.

## Why

- **Advisory:** GHSA-82j2-j2ch-gfr8 == RUSTSEC-2026-0104 - rustls-webpki DoS via a malformed CRL BIT STRING.
- **Severity:** CVSS 7.5 **HIGH**.
- **Affected:** `rustls-webpki < 0.103.13`; **fixed in 0.103.13**.

This resolves the repository's open Dependabot alert for rustls-webpki. **Dependabot did not auto-PR** this because it is a **transitive / lockfile-only** dependency (pulled in via `rustls 0.23.38`), so there is no direct `Cargo.toml` entry for it to bump.

## Residual (needs manual follow-up)

A **second, older copy remains: `rustls-webpki 0.102.8`**, pinned transitively by `async-nats 0.45`. The `0.102.x` line has **no fixed release** (it ends at the vulnerable 0.102.8; the fix only exists in 0.103.13+). Lifting this copy would require a **parent-crate upgrade of `async-nats` in `Cargo.toml`** (a non-lockfile, potentially breaking change), which is **out of scope for this lockfile-only security PR**. It needs a separate, manually-reviewed `async-nats` upgrade. Therefore this PR fixes the `0.103.x` copy but does **not** fully clear the advisory across the dependency graph.

## Provenance

- Commit is **ssh-signed** (key `SHA256:kVP7Nb+Js58NvZPglm0gByBC9KeYLl/tqWpHkNN9gUA`).
- Branch was cut from **fresh `origin/main`** (new clone).
- Only `disinfo-nesy-detector/Cargo.lock` is changed (note: `.gitattributes` marks `Cargo.lock` with `-diff`, so GitHub may render it as binary; the change is version 0.103.11->0.103.13 + matching checksum).

**Security PR -> manual review, do not auto-merge.**

Generated with Claude Code.